### PR TITLE
Support transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ rc = Renoir::Client.new(
 
   # redis-rb options
   timeout: 100,
-  password: 'password'
+  password: 'password',
+  driver: :hiredis
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ rc = Renoir::Client.new(
 )
 ```
 
+### Pipelining
+
+Command pipelining is supported although "future" variable is not available at this point.
+
+```ruby
+rc.pipeliend do |pipeline|
+  pipeline.set('hoge{1}', 123)
+  pipeline.get('hoge{1}')
+  pipeline.get('fuga{1}')
+end
+# => ["OK", "123", nil]
+```
+
+If pipelined commands use different slot of key, it fails without dispatching command.
+
+You can also execute commands atomically with `#multi`:
+
+```ruby
+rc.multi do |pipeline|
+  pipeline.set('hoge{1}', 123)
+  pipeline.get('hoge{1}')
+  pipeline.get('fuga{1}')
+end
+# => ["OK", "123", nil]
+```
+
 ### Dispatch command to nodes directly
 
 Renoir dispatches a command only if a slot is determined by the command. This also includes no-keys commands like `KEYS`, `BGSAVE` and so on.

--- a/lib/renoir/client.rb
+++ b/lib/renoir/client.rb
@@ -62,6 +62,14 @@ module Renoir
       call_with_redirection(slot, [[:multi]] + commands + [[:exec]])
     end
 
+    def pipelined(&block)
+      commands = pipeline_commands(&block)
+      slot = get_slot_from_commands(commands)
+
+      refresh_slots
+      call_with_redirection(slot, commands)
+    end
+
     def call(*command, &block)
       slot = get_slot_from_commands([command])
 

--- a/lib/renoir/client.rb
+++ b/lib/renoir/client.rb
@@ -50,7 +50,7 @@ module Renoir
     end
 
     def eval(*args, &block)
-      call(eval, *args, &block)
+      call(:eval, *args, &block)
     end
 
     def call(*command, &block)

--- a/lib/renoir/connection_adapters/base.rb
+++ b/lib/renoir/connection_adapters/base.rb
@@ -7,7 +7,7 @@ module Renoir
         end
       end
 
-      def call(command, asking=false, &block)
+      def call(commands, asking=false, &block)
         fail "a connection adapter must override #call"
       end
 

--- a/lib/renoir/connection_adapters/redis.rb
+++ b/lib/renoir/connection_adapters/redis.rb
@@ -66,7 +66,7 @@ module Renoir
             commands.each do |command, *args|
               tx.send(command, *args, &block)
             end
-          end
+          end.slice(1..-1)
         elsif commands.size > 1
           @conn.pipelined do |pipeline|
             commands.each do |command, *args|

--- a/lib/renoir/pipeline.rb
+++ b/lib/renoir/pipeline.rb
@@ -1,0 +1,21 @@
+module Renoir
+  class Pipeline
+    attr_reader :commands
+
+    def initialize(options={})
+      @commands = []
+    end
+
+    def eval(*args)
+      call(:eval, *args)
+    end
+
+    def call(*command)
+      @commands << command
+    end
+
+    def method_missing(command, *args, &block)
+      call(command, *args, &block)
+    end
+  end
+end

--- a/test/connection_adapters/redis_test.rb
+++ b/test/connection_adapters/redis_test.rb
@@ -56,4 +56,16 @@ class RenoirConnectionAdaptersRedisTest < Minitest::Test
     assert @adapter.call([[:info]], true).size == 1
     assert @conn.instance_variable_get(:@asked)
   end
+
+  def test_call_with_multi
+    assert_raises RuntimeError do
+      @adapter.call([[:multi], [:info]], false)
+    end
+
+    assert @adapter.call([[:multi], [:info], [:exec]], false).size == 1
+  end
+
+  def test_call_with_multiple_commands
+    assert @adapter.call([[:info], [:info]], false).size == 2
+  end
 end

--- a/test/connection_adapters/redis_test.rb
+++ b/test/connection_adapters/redis_test.rb
@@ -43,7 +43,7 @@ class RenoirConnectionAdaptersRedisTest < Minitest::Test
     conn_mock.expect(:info, true)
     @adapter.instance_variable_set(:@conn, conn_mock)
 
-    @adapter.call([:info], false)
+    @adapter.call([[:info]], false)
 
     conn_mock.verify
   end
@@ -59,7 +59,7 @@ class RenoirConnectionAdaptersRedisTest < Minitest::Test
     end.new(tx_mock)
     @adapter.instance_variable_set(:@conn, conn_mock)
 
-    @adapter.call([:info], true)
+    @adapter.call([[:info]], true)
 
     tx_mock.verify
   end

--- a/test/connection_adapters/redis_test.rb
+++ b/test/connection_adapters/redis_test.rb
@@ -15,6 +15,7 @@ class RenoirConnectionAdaptersRedisTest < Minitest::Test
                  end
     @klass = Renoir::ConnectionAdapters::Redis
     @adapter = @klass.new(host, port)
+    @conn = @adapter.instance_variable_get(:@conn)
   end
 
   def test_get_keys_from_command
@@ -39,28 +40,20 @@ class RenoirConnectionAdaptersRedisTest < Minitest::Test
   end
 
   def test_call_without_asking
-    conn_mock = Minitest::Mock.new
-    conn_mock.expect(:info, true)
-    @adapter.instance_variable_set(:@conn, conn_mock)
-
-    @adapter.call([[:info]], false)
-
-    conn_mock.verify
+    def @conn.asking
+      call(:asking)
+      @asked = true
+    end
+    assert @adapter.call([[:info]], false).size == 1
+    refute @conn.instance_variable_get(:@asked)
   end
 
   def test_call_with_asking
-    tx_mock = Minitest::Mock.new
-    tx_mock.expect(:asking, true)
-    tx_mock.expect(:info, true)
-    conn_mock = Struct.new(:tx_mock) do
-      def multi
-        yield tx_mock
-      end
-    end.new(tx_mock)
-    @adapter.instance_variable_set(:@conn, conn_mock)
-
-    @adapter.call([[:info]], true)
-
-    tx_mock.verify
+    def @conn.asking
+      call(:asking)
+      @asked = true
+    end
+    assert @adapter.call([[:info]], true).size == 1
+    assert @conn.instance_variable_get(:@asked)
   end
 end

--- a/test/renoir_client_redis_test.rb
+++ b/test/renoir_client_redis_test.rb
@@ -7,6 +7,14 @@ class RenoirClientRedisTest < Minitest::Test
     )
   end
 
+  def test_eval
+    assert_raises RuntimeError do
+      @client.eval('return {KEYS[1]}', keys: [])
+    end
+
+    assert @client.eval('return {KEYS[1]}', keys: ['hoge']) == ['hoge']
+  end
+
   def test_call_single_key_command
     assert @client.set('hoge', 123) == 'OK'
     assert @client.set('fuga', 'piyo') == 'OK'

--- a/test/renoir_client_redis_test.rb
+++ b/test/renoir_client_redis_test.rb
@@ -15,6 +15,23 @@ class RenoirClientRedisTest < Minitest::Test
     assert @client.eval('return {KEYS[1]}', keys: ['hoge']) == ['hoge']
   end
 
+  def test_multi
+    assert_raises RuntimeError do
+      @client.multi do |tx|
+        tx.get('hoge')
+        tx.info
+        tx.get('fuga')
+      end
+    end
+
+    res = @client.multi do |tx|
+      tx.get('hoge{1}')
+      tx.info
+      tx.get('fuga{1}')
+    end
+    assert res.size == 3
+  end
+
   def test_call_single_key_command
     assert @client.set('hoge', 123) == 'OK'
     assert @client.set('fuga', 'piyo') == 'OK'

--- a/test/renoir_client_redis_test.rb
+++ b/test/renoir_client_redis_test.rb
@@ -32,6 +32,23 @@ class RenoirClientRedisTest < Minitest::Test
     assert res.size == 3
   end
 
+  def test_pipelined
+    assert_raises RuntimeError do
+      @client.pipelined do |tx|
+        tx.get('hoge')
+        tx.info
+        tx.get('fuga')
+      end
+    end
+
+    res = @client.pipelined do |tx|
+      tx.get('hoge{1}')
+      tx.info
+      tx.get('fuga{1}')
+    end
+    assert res.size == 3
+  end
+
   def test_call_single_key_command
     assert @client.set('hoge', 123) == 'OK'
     assert @client.set('fuga', 'piyo') == 'OK'


### PR DESCRIPTION
Implements `Renoir::Client#multi` and `#pipelined`.
